### PR TITLE
Allow backends to opt out of unloading

### DIFF
--- a/include/core/jbackend.h
+++ b/include/core/jbackend.h
@@ -116,7 +116,8 @@ typedef enum JBackendType JBackendType;
 enum JBackendComponent
 {
 	J_BACKEND_COMPONENT_CLIENT = 1 << 0,
-	J_BACKEND_COMPONENT_SERVER = 1 << 1
+	J_BACKEND_COMPONENT_SERVER = 1 << 1,
+	J_BACKEND_COMPONENT_NOT_UNLOADABLE = 1 << 2
 };
 
 typedef enum JBackendComponent JBackendComponent;

--- a/lib/db/jdb.c
+++ b/lib/db/jdb.c
@@ -82,15 +82,23 @@ j_db_fini(void)
 		return;
 	}
 
+	gboolean do_unload = TRUE;
 	if (j_db_backend != NULL)
 	{
+		if (j_db_backend->component & J_BACKEND_COMPONENT_NOT_UNLOADABLE)
+		{
+			do_unload = false;
+		}
 		j_backend_db_fini(j_db_backend);
 		j_db_backend = NULL;
 	}
 
 	if (j_db_module != NULL)
 	{
-		g_module_close(j_db_module);
+		if (do_unload)
+		{
+			g_module_close(j_db_module);
+		}
 		j_db_module = NULL;
 	}
 }

--- a/lib/kv/jkv.c
+++ b/lib/kv/jkv.c
@@ -136,15 +136,23 @@ j_kv_fini(void)
 		return;
 	}
 
+	gboolean do_unload = TRUE;
 	if (j_kv_backend != NULL)
 	{
+		if (j_kv_backend->component & J_BACKEND_COMPONENT_NOT_UNLOADABLE)
+		{
+			do_unload = false;
+		}
 		j_backend_kv_fini(j_kv_backend);
 		j_kv_backend = NULL;
 	}
 
 	if (j_kv_module != NULL)
 	{
-		g_module_close(j_kv_module);
+		if (do_unload)
+		{
+			g_module_close(j_kv_module);
+		}
 		j_kv_module = NULL;
 	}
 }

--- a/lib/object/jobject.c
+++ b/lib/object/jobject.c
@@ -149,15 +149,23 @@ j_object_fini(void)
 		return;
 	}
 
+	gboolean do_unload = TRUE;
 	if (j_object_backend != NULL)
 	{
+		if (j_object_backend->component & J_BACKEND_COMPONENT_NOT_UNLOADABLE)
+		{
+			do_unload = false;
+		}
 		j_backend_object_fini(j_object_backend);
 		j_object_backend = NULL;
 	}
 
 	if (j_object_module != NULL)
 	{
-		g_module_close(j_object_module);
+		if (do_unload)
+		{
+			g_module_close(j_object_module);
+		}
 		j_object_module = NULL;
 	}
 }

--- a/server/server.c
+++ b/server/server.c
@@ -393,17 +393,17 @@ main(int argc, char** argv)
 		j_backend_object_fini(jd_object_backend);
 	}
 
-	if (db_module != NULL)
+	if (jd_db_backend && db_module && !(jd_db_backend->component & J_BACKEND_COMPONENT_NOT_UNLOADABLE))
 	{
 		g_module_close(db_module);
 	}
 
-	if (kv_module != NULL)
+	if (jd_kv_backend && kv_module && !(jd_kv_backend->component & J_BACKEND_COMPONENT_NOT_UNLOADABLE))
 	{
 		g_module_close(kv_module);
 	}
 
-	if (object_module)
+	if (jd_object_backend && object_module && !(jd_object_backend->component & J_BACKEND_COMPONENT_NOT_UNLOADABLE))
 	{
 		g_module_close(object_module);
 	}


### PR DESCRIPTION
For example, if the module registers atexit callbacks with glibc,
it can't be unloaded before those are run, or the process with segfault
after main.

It's actually not required in the client part for me, it appears that the client fini runs after the Rust TLS destructor, but the running
order of destructors is not something that should be relied on.